### PR TITLE
add collision and law of gravitation universal to the options on issue #5

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,8 +122,8 @@ function App() {
 
   useEffect(() => {
     if (playing && measures) {
-      for(let i = 0; i < options.papers.length; i++) {
-        const paper = options.papers[i]
+      for(const paper of options.papers) {
+        handleHit(paper, options.papers)
         const hit = handleHit(paper, options.scissors)
         if (hit) {
           dispatch({
@@ -134,8 +134,8 @@ function App() {
         }
       }
 
-      for(let i = 0; i < options.rocks.length; i++) {
-        const rock = options.rocks[i]
+      for(const rock of options.rocks) {
+        handleHit(rock, options.rocks)
         const hit = handleHit(rock, options.papers)
         if (hit) {
           dispatch({
@@ -146,8 +146,8 @@ function App() {
         }
       }
 
-      for(let i = 0; i < options.scissors.length; i++) {
-        const scissors = options.scissors[i]
+      for(const scissors of options.scissors) {
+        handleHit(scissors, options.scissors)
         const hit = handleHit(scissors, options.rocks)
         if (hit) {
           dispatch({

--- a/src/contexts/GameContext.tsx
+++ b/src/contexts/GameContext.tsx
@@ -18,96 +18,171 @@ type Action =
   | { type: ActionType.TRANSFER_OPTIONS; payload: Option; to: 'scissors' | 'rocks' | 'papers'; left?: number; top?: number; right?: number; bottom?: number }
   | { type: ActionType.SET_OPTIONS; payload: OptionsState; top?: number; left?: number; right?: number; bottom?: number }
 
-export const handleHit = (option: Option, optionList: Option[]) => {
-  const hit = optionList.some(item => {
-    return (
-      option.x > item.x - 20 &&
-      option.x < item.x + 20 &&
-      option.y > item.y - 20 &&
-      option.y < item.y + 20
-    )
-  })
-
-  return hit
-}
+  export const handleHit = (option: Option, optionList: Option[]) => {
+    for (const item of optionList) {
+      if (item === option) {
+        continue;
+      }
+  
+      const dx = item.x - option.x;
+      const dy = item.y - option.y;
+      const d = Math.sqrt(dx * dx + dy * dy);
+      
+      if (d < 20) {
+        const relativeVelX = item.velh - option.velh;
+        const relativeVelY = item.velv - option.velv;
+  
+        const normalX = dx / d;
+        const normalY = dy / d;
+  
+        const relativeVelocity = relativeVelX * normalX + relativeVelY * normalY;
+  
+        if (relativeVelocity < 0) {
+          const elasticity = 0.9;
+  
+          const impulse = (2 * relativeVelocity) / (1 / item.mass + 1 / option.mass);
+  
+          item.velh -= impulse * normalX / item.mass * elasticity;
+          item.velv -= impulse * normalY / item.mass * elasticity;
+          option.velh += impulse * normalX / option.mass * elasticity;
+          option.velv += impulse * normalY / option.mass * elasticity;
+        }
+        
+        return true
+      }
+    }
+  
+    return false;
+  };
+  
 
 const reducer = (state: OptionsState, action: Action) => {
   switch (action.type) {
-  case ActionType.CREATE_OPTIONS: {
-    const options = ['scissors', 'rocks', 'papers']
-    const optionsState: OptionsState = {
-      scissors: [],
-      rocks: [],
-      papers: []
-    }
-
-    const { left, top, right, bottom } = action
-    if (!left || !top || !right || !bottom) return state
-
-    options.forEach(option => {
-      for (let i = 0; i < 10; i++) {
-        const x = Math.floor(Math.random() * (right - left)) + left
-        const y = Math.floor(Math.random() * (bottom - top)) + top
-        const id = `${option}-${i}`
-        const value = option === 'scissors' ? '✂️' : option === 'rocks' ? '🪨' : '📄'
-        const optionObj = { value, x, y, id }
-
-        if (option === 'scissors') {
-          optionsState.scissors.push(optionObj)
-        } else if (option === 'rocks') {
-          optionsState.rocks.push(optionObj)
-        } else {
-          optionsState.papers.push(optionObj)
-        }
+    case ActionType.CREATE_OPTIONS: {
+      const options = ['scissors', 'rocks', 'papers']
+      const optionsState: OptionsState = {
+        scissors: [],
+        rocks: [],
+        papers: []
       }
-    })
 
-    return optionsState
-  }
-  case ActionType.TRANSFER_OPTIONS: {
-    const { payload, to } = action
-    const from = to === 'scissors' ? 'papers' : to === 'rocks' ? 'scissors' : 'rocks'
-  
-    const newOption = {
-      ...payload,
-      value: to === 'scissors' ? '✂️' : to === 'rocks' ? '🪨' : '📄'
-    }
+      const { left, top, right, bottom } = action
+      if (!left || !top || !right || !bottom) return state
 
-    const newOptionsState = {
-      ...state,
-      [from]: state[from].filter(option => option.id !== payload.id),
-      [to]: [...state[to], newOption]
-    }
+      options.forEach(option => {
+        for (let i = 0; i < 10; i++) {
+          const x = Math.floor(Math.random() * (right - left)) + left
+          const y = Math.floor(Math.random() * (bottom - top)) + top
+          const id = `${option}-${i}`
+          const acelv = 0
+          const acelh = 0
+          const velh = 0
+          const velv = 0
+          const mass = Math.random() * 10
+          const value = option === 'scissors' ? '✂️' : option === 'rocks' ? '🪨' : '📄'
+          const optionObj = { value, x, y, id, acelh, acelv, velh, velv, mass }
 
-    return newOptionsState
-  }
-  case ActionType.SET_OPTIONS: {
-    const { payload } = action
-    const newState = { ...state }
-
-    const { left, top, right, bottom } = action
-    if (!left || !top || !right || !bottom) return state
-
-    Object.keys(payload).forEach(key => {
-      const optionList = payload[key]
-      const newOptionList = optionList.map(option => {
-        const { x, y } = option
-        const newX = Math.round(Math.random() * 10 - 5 + x)
-        const newY = Math.round(Math.random() * 10 - 5 + y)
-        return {
-          ...option,
-          x: newX > left && newX < right ? newX : option.x,
-          y: newY > top && newY < bottom ? newY : option.y
+          if (option === 'scissors') {
+            optionsState.scissors.push(optionObj)
+          } else if (option === 'rocks') {
+            optionsState.rocks.push(optionObj)
+          } else {
+            optionsState.papers.push(optionObj)
+          }
         }
       })
 
-      newState[key] = newOptionList
-    })
+      return optionsState
+    }
+    case ActionType.TRANSFER_OPTIONS: {
+      const { payload, to } = action
+      const from = to === 'scissors' ? 'papers' : to === 'rocks' ? 'scissors' : 'rocks'
 
-    return newState
-  }
-  default:
-    return state
+      const newOption = {
+        ...payload,
+        value: to === 'scissors' ? '✂️' : to === 'rocks' ? '🪨' : '📄'
+      }
+
+      const newOptionsState = {
+        ...state,
+        [from]: state[from].filter(option => option.id !== payload.id),
+        [to]: [...state[to], newOption]
+      }
+
+      return newOptionsState
+    }
+    case ActionType.SET_OPTIONS: {
+      const { payload } = action
+      const newState = { ...state }
+
+      const { left, top, right, bottom } = action
+      if (!left || !top || !right || !bottom) return state
+      let allOptions: Option[] = []
+      Object.keys(payload).forEach(key => {
+        const options = payload[key]
+        allOptions.push(...options)
+      })
+      Object.keys(payload).forEach(key => {
+        const optionList = payload[key]
+        const newOptionList = optionList.map(option => {
+          const { x, y, velh, velv, mass } = option
+
+          option.acelh = 0
+          option.acelv = 0
+          allOptions.forEach(element => {
+            let fx = 0
+            let fy = 0
+            let seno = 0
+            let cose = 0
+
+            const dy = element.y - y
+            const dx = element.x - x
+            const d = Math.sqrt((dx * dx) + (dy * dy))
+
+            if (d > 0) {
+              const f = (mass * element.mass) / d
+              fx += (f * dx)
+              fy += (f * dy)
+              seno = dy / d
+              cose = dx / d
+
+              let acel = f / mass;
+              option.acelh = acel * cose;
+              option.acelv = acel * seno;
+
+            }
+          });
+          
+          let newVelh = velh + option.acelh
+          let newVelv = velv + option.acelv
+          let newX = x + newVelh
+          let newY = y + newVelv
+
+          if (!(newX > left && newX < right)) {
+            newX = option.x
+            newVelh *= -1
+          }
+
+          if (!(newY > top && newY < bottom)) {
+            newY = option.y
+            newVelv *= -1
+          }
+          return {
+            ...option,
+            velv: newVelv,
+            velh: newVelh,
+            x: newX,
+            y: newY
+          }
+        })
+
+        newState[key] = newOptionList
+      })
+
+      return newState
+    }
+    default:
+      return state
   }
 }
 

--- a/src/contexts/GameContext.tsx
+++ b/src/contexts/GameContext.tsx
@@ -51,7 +51,6 @@ type Action =
         return true
       }
     }
-  
     return false;
   };
   
@@ -130,8 +129,6 @@ const reducer = (state: OptionsState, action: Action) => {
           option.acelh = 0
           option.acelv = 0
           allOptions.forEach(element => {
-            let fx = 0
-            let fy = 0
             let seno = 0
             let cose = 0
 
@@ -141,8 +138,6 @@ const reducer = (state: OptionsState, action: Action) => {
 
             if (d > 0) {
               const f = (mass * element.mass) / d
-              fx += (f * dx)
-              fy += (f * dy)
               seno = dy / d
               cose = dx / d
 

--- a/src/contexts/GameContext.tsx
+++ b/src/contexts/GameContext.tsx
@@ -29,23 +29,23 @@ type Action =
       const d = Math.sqrt(dx * dx + dy * dy);
       
       if (d < 20) {
-        const relativeVelX = item.velh - option.velh;
-        const relativeVelY = item.velv - option.velv;
+        const relativeSpeedX = item.speedH - option.speedH;
+        const relativeSpeedY = item.speedV - option.speedV;
   
         const normalX = dx / d;
         const normalY = dy / d;
   
-        const relativeVelocity = relativeVelX * normalX + relativeVelY * normalY;
+        const relativeSpeed = relativeSpeedX * normalX + relativeSpeedY * normalY;
   
-        if (relativeVelocity < 0) {
+        if (relativeSpeed < 0) {
           const elasticity = 0.9;
   
-          const impulse = (2 * relativeVelocity) / (1 / item.mass + 1 / option.mass);
+          const impulse = (2 * relativeSpeed) / (1 / item.mass + 1 / option.mass);
   
-          item.velh -= impulse * normalX / item.mass * elasticity;
-          item.velv -= impulse * normalY / item.mass * elasticity;
-          option.velh += impulse * normalX / option.mass * elasticity;
-          option.velv += impulse * normalY / option.mass * elasticity;
+          item.speedH -= impulse * normalX / item.mass * elasticity;
+          item.speedV -= impulse * normalY / item.mass * elasticity;
+          option.speedH += impulse * normalX / option.mass * elasticity;
+          option.speedV += impulse * normalY / option.mass * elasticity;
         }
         
         return true
@@ -73,13 +73,13 @@ const reducer = (state: OptionsState, action: Action) => {
           const x = Math.floor(Math.random() * (right - left)) + left
           const y = Math.floor(Math.random() * (bottom - top)) + top
           const id = `${option}-${i}`
-          const acelv = 0
-          const acelh = 0
-          const velh = 0
-          const velv = 0
-          const mass = Math.random() * 10
+          const accelerationV = 0
+          const accelerationH = 0
+          const speedH = 0
+          const speedV = 0
           const value = option === 'scissors' ? '✂️' : option === 'rocks' ? '🪨' : '📄'
-          const optionObj = { value, x, y, id, acelh, acelv, velh, velv, mass }
+          const mass = new Blob([value]).size
+          const optionObj = { value, x, y, id, accelerationH, accelerationV, speedH, speedV, mass }
 
           if (option === 'scissors') {
             optionsState.scissors.push(optionObj)
@@ -124,10 +124,10 @@ const reducer = (state: OptionsState, action: Action) => {
       Object.keys(payload).forEach(key => {
         const optionList = payload[key]
         const newOptionList = optionList.map(option => {
-          const { x, y, velh, velv, mass } = option
+          const { x, y, speedH, speedV, mass } = option
 
-          option.acelh = 0
-          option.acelv = 0
+          option.accelerationH = 0
+          option.accelerationV = 0
           allOptions.forEach(element => {
             let seno = 0
             let cose = 0
@@ -142,30 +142,30 @@ const reducer = (state: OptionsState, action: Action) => {
               cose = dx / d
 
               let acel = f / mass;
-              option.acelh = acel * cose;
-              option.acelv = acel * seno;
+              option.accelerationH = acel * cose;
+              option.accelerationV = acel * seno;
 
             }
           });
           
-          let newVelh = velh + option.acelh
-          let newVelv = velv + option.acelv
-          let newX = x + newVelh
-          let newY = y + newVelv
+          let newspeedH = speedH + option.accelerationH
+          let newspSpeedV = speedV + option.accelerationV
+          let newX = x + newspeedH
+          let newY = y + newspSpeedV
 
           if (!(newX > left && newX < right)) {
             newX = option.x
-            newVelh *= -1
+            newspeedH *= -1
           }
 
           if (!(newY > top && newY < bottom)) {
             newY = option.y
-            newVelv *= -1
+            newspSpeedV *= -1
           }
           return {
             ...option,
-            velv: newVelv,
-            velh: newVelh,
+            speedV: newspSpeedV,
+            speedH: newspeedH,
             x: newX,
             y: newY
           }

--- a/src/types/game.d.ts
+++ b/src/types/game.d.ts
@@ -4,6 +4,11 @@ declare type Option = {
   value: string;
   x: number;
   y: number;
+  velh: number;
+  velv: number;
+  acelh: number;
+  acelv: number;
+  mass: number;
   id: string;
 }
 

--- a/src/types/game.d.ts
+++ b/src/types/game.d.ts
@@ -4,10 +4,10 @@ declare type Option = {
   value: string;
   x: number;
   y: number;
-  velh: number;
-  velv: number;
-  acelh: number;
-  acelv: number;
+  speedH: number;
+  speedV: number;
+  accelerationH: number;
+  accelerationV: number;
   mass: number;
   id: string;
 }


### PR DESCRIPTION
This pull request addresses issue #5.

In this pull request, I've added code to calculate the force and collision between two "Option" objects in the game. To achieve this, I've introduced the following properties to the "Option" objects: mass, velocity, and acceleration.

Changes Made:
- Added mass property to the "Option" objects.
- Added velocity property to the "Option" objects.
- Added acceleration property to the "Option" objects.
- Calculated the force between two "Option" objects.
- Calculated collision between two "Option" objects.

These changes are necessary to improve the game's physics simulation and allow for more realistic interactions between the objects.

Please review the code for correctness and let me know if any further adjustments are required.

- This code calculate the force between two "Option" (law of universal gravitation)
![image](https://github.com/datsfilipe/react-jokenpo/assets/96489518/f61bd457-8b9b-4305-a871-59bc45463452)

- This code calculate the collisions  between two "Option" (Elastic collision)
![image](https://github.com/datsfilipe/react-jokenpo/assets/96489518/1c1a5e67-ef50-4495-abac-2c1d971962d6)

